### PR TITLE
Round ms in 'Took' message on search screen

### DIFF
--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -264,7 +264,7 @@
   </form>
   <div class="stats px-6 md:px-12 py-6 text-sm text-slate-400">
     {#if res}
-      Showing {results?.length} of {res.count}. Took <code>{res.perfMs}</code>ms.
+      Showing {results?.length} of {res.count}. Took <code>{Math.round(10*res.perfMs)/10}</code>ms.
     {:else if stats && $displaySettings.showStats}
       <div class="inline-stats flex space-x-4" in:fly|local={{ y: -20, duration: 150 }}>
         {#each Object.entries(stats) as [k, v]}


### PR DESCRIPTION
Very nice extension, thank you!

This was niggling me:
![image](https://github.com/iansinnott/full-text-tabs-forever/assets/5624098/455edec0-a9d0-4454-a4a0-f3ba908015cd)

It now looks like this:
![image](https://github.com/iansinnott/full-text-tabs-forever/assets/5624098/50aca9f5-b8eb-4f86-8565-1e854498bf50)


