### PR TITLE
Larger titles in results + spacing

### DIFF
--- a/src/ui/App.svelte
+++ b/src/ui/App.svelte
@@ -302,15 +302,15 @@
           showDetails = true;
         }}
       >
-        <a class="result" href={url} on:click|preventDefault>
-          <div class="favicon mr-3">
+        <a class="result mb-1" href={url} on:click|preventDefault>
+          <div class="favicon mr-3 self-center">
             <img
               class="w-4 h-4 rounded-lg"
               src={getFaviconByUrl(url)}
               alt="favicon for {u.hostname}"
             />
           </div>
-          <div class="title mr-3 text-slate-300">{@html group.title}</div>
+          <div class="title mr-3 text-slate-300 text-base">{@html group.title}</div>
           <div class="url truncate text-indigo-200">
             {@html group.displayUrl}
           </div>
@@ -376,5 +376,6 @@
     display: grid;
     grid-template-columns: auto auto minmax(0, 1fr);
     grid-template-rows: auto minmax(0, 1fr);
+    align-items: baseline;
   }
 </style>


### PR DESCRIPTION
Perhaps a bit subjective, but I find it easier to scan the results if the heading pops a bit more. Trade-off: we lose a little bit on vertical space.

Before:
![image](https://github.com/iansinnott/full-text-tabs-forever/assets/5624098/6bf4559f-527d-4c09-b064-53eaac15f4d8)

After:
![image](https://github.com/iansinnott/full-text-tabs-forever/assets/5624098/a869f55f-ebb0-4c62-b388-8de31d8d86a5)

